### PR TITLE
Add CIFAR-10 ML training example

### DIFF
--- a/examples/cifar10_classification/README.md
+++ b/examples/cifar10_classification/README.md
@@ -1,0 +1,20 @@
+# CIFAR-10 Classification Example
+
+This example demonstrates how OpenEvolve can improve a basic image classification model on the CIFAR-10 dataset.
+
+The initial program defines three functions:
+
+- `load_data()` – downloads CIFAR-10 and returns training and test loaders.
+- `init_model()` – creates a very small convolutional neural network.
+- `train()` – trains the model and prints the loss and accuracy at each epoch.
+
+The evaluator uses cascade evaluation. The first stage trains for a single epoch
+with a short timeout. If the accuracy after the first epoch exceeds a threshold,
+the second stage runs a longer training session.
+
+Run the example with:
+
+```bash
+cd examples/cifar10_classification
+python ../../openevolve-run.py initial_program.py evaluator.py --config config.yaml
+```

--- a/examples/cifar10_classification/config.yaml
+++ b/examples/cifar10_classification/config.yaml
@@ -1,0 +1,36 @@
+# Configuration for CIFAR-10 example
+max_iterations: 100
+checkpoint_interval: 10
+log_level: "INFO"
+
+llm:
+  primary_model: "llama3.1-8b"
+  primary_model_weight: 0.8
+  secondary_model: "llama-4-scout-17b-16e-instruct"
+  secondary_model_weight: 0.2
+  api_base: "https://api.cerebras.ai/v1"
+  temperature: 0.7
+  top_p: 0.95
+  max_tokens: 4096
+
+prompt:
+  system_message: "You are an expert in deep learning. Improve the CIFAR-10 classification program."
+  num_top_programs: 3
+  use_template_stochasticity: true
+
+database:
+  population_size: 50
+  archive_size: 20
+  num_islands: 3
+  elite_selection_ratio: 0.2
+  exploitation_ratio: 0.7
+
+evaluator:
+  timeout: 120
+  cascade_evaluation: true
+  cascade_thresholds: [0.4, 0.6]
+  parallel_evaluations: 2
+  use_llm_feedback: false
+
+diff_based_evolution: true
+allow_full_rewrites: false

--- a/examples/cifar10_classification/evaluator.py
+++ b/examples/cifar10_classification/evaluator.py
@@ -1,0 +1,50 @@
+"""Evaluator for CIFAR-10 classification example"""
+
+import importlib.util
+import io
+import contextlib
+from typing import Dict
+
+
+def _load_program(path: str):
+    spec = importlib.util.spec_from_file_location("program", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def evaluate(program_path: str) -> Dict[str, float]:
+    """Full evaluation running for several epochs"""
+    try:
+        prog = _load_program(program_path)
+        train_loader, test_loader = prog.load_data()
+        model = prog.init_model()
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            acc = prog.train(model, train_loader, test_loader, epochs=5)
+        log = f.getvalue()
+        return {"accuracy": float(acc), "log": log[-2000:]}
+    except Exception as e:
+        return {"accuracy": 0.0, "error": str(e)}
+
+
+# Cascade evaluation helpers
+
+def evaluate_stage1(program_path: str) -> Dict[str, float]:
+    """Train for a single epoch and return accuracy"""
+    try:
+        prog = _load_program(program_path)
+        train_loader, test_loader = prog.load_data()
+        model = prog.init_model()
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            acc = prog.train(model, train_loader, test_loader, epochs=1)
+        out = f.getvalue()
+        return {"stage1_acc": float(acc), "stdout": out}
+    except Exception as e:
+        return {"stage1_acc": 0.0, "error": str(e)}
+
+
+def evaluate_stage2(program_path: str) -> Dict[str, float]:
+    """Run the full evaluation"""
+    return evaluate(program_path)

--- a/examples/cifar10_classification/initial_program.py
+++ b/examples/cifar10_classification/initial_program.py
@@ -1,0 +1,95 @@
+"""Basic CIFAR-10 training script"""
+
+# EVOLVE-BLOCK-START
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+
+def load_data(batch_size: int = 64):
+    """Load CIFAR-10 dataset"""
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+    ])
+    train_set = datasets.CIFAR10(root="./data", train=True, download=True, transform=transform)
+    test_set = datasets.CIFAR10(root="./data", train=False, download=True, transform=transform)
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_set, batch_size=batch_size, shuffle=False)
+    return train_loader, test_loader
+
+
+class SimpleCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 16, 3, padding=1)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.fc1 = nn.Linear(16 * 16 * 16, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        return x
+
+
+def init_model():
+    """Create model instance"""
+    return SimpleCNN()
+
+
+def train(model, train_loader, test_loader, epochs: int = 1, device=None):
+    """Train the model and print stats each epoch"""
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    for epoch in range(epochs):
+        model.train()
+        running_loss = 0.0
+        for inputs, targets in train_loader:
+            inputs, targets = inputs.to(device), targets.to(device)
+            optimizer.zero_grad()
+            outputs = model(inputs)
+            loss = criterion(outputs, targets)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+
+        avg_loss = running_loss / len(train_loader)
+        test_acc = evaluate(model, test_loader, device)
+        print(f"Epoch {epoch + 1}/{epochs} - loss: {avg_loss:.4f} - acc: {test_acc:.4f}")
+    return test_acc
+
+
+def evaluate(model, loader, device):
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for inputs, targets in loader:
+            inputs, targets = inputs.to(device), targets.to(device)
+            outputs = model(inputs)
+            _, predicted = torch.max(outputs, 1)
+            total += targets.size(0)
+            correct += (predicted == targets).sum().item()
+    return correct / total
+
+# EVOLVE-BLOCK-END
+
+
+# Fixed entry point
+
+def run_training():
+    train_loader, test_loader = load_data()
+    model = init_model()
+    acc = train(model, train_loader, test_loader, epochs=5)
+    return acc
+
+
+if __name__ == "__main__":
+    final_acc = run_training()
+    print(f"Final accuracy: {final_acc}")

--- a/examples/cifar10_classification/requirements.txt
+++ b/examples/cifar10_classification/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torchvision


### PR DESCRIPTION
## Summary
- add a new `cifar10_classification` example
- include a simple CNN program with load, init and train functions
- implement evaluator with cascade evaluation
- provide example configuration and README

## Testing
- `pip install pyyaml numpy openai`
- `PYTHONPATH=. pytest -q tests/test_valid_configs.py`

------
https://chatgpt.com/codex/tasks/task_b_686ba923e4fc832d8c93c748f777567d